### PR TITLE
Fix out-of-bounds array access

### DIFF
--- a/src/pdf/blackjack_split.cpp
+++ b/src/pdf/blackjack_split.cpp
@@ -171,7 +171,7 @@ struct Game
     std::vector<State> get_moves(const State& s)
     {
         std::vector<State> moves;
-        std::int8_t hand = s.hands[s.current];
+        std::int8_t hand = s.hands[s.current % 4];
         if (s.current == 4 || hand == 0)
         {
             return moves;


### PR DESCRIPTION
While this address will land on State::current and therefore inside a valid object, it's beyond the end of the indexed object (hands) and so the operation is undefined. You can confirm this with Undefined Behavior Sanitizer, which triggers here when s.current == 4.

What are the consequences? Since hands is an array of 4 elements, and s.current is used as a subscript on this array, a compiler may freely assume 0 <= s.current < 4 at that moment. This information may propagate both forwards and backwards in flow analysis. For the condition on the next line, it may determine that s.current == 4 is always false and delete the check.

I resolved it by masking the subscript so that it wraps back to zero in the beyond-the-end case. Since the intended behavior was fine at a low level, it's unfortunate that a high-level fixes isn't free (in practice the mask isn't optimized out). So I picked the simplest.

* * *

If you'd like to catch issues like this in w64devkit, compile with `-fsanitize=undefined -fsanitize-trap`, then run it under GDB (as, IMHO, ought to be the case anyway). You don't get a diagnostic, but on the other hand, it traps directly on the offending line.

I looked at code generation at `-O2` for a few options and, man, the build times for this mere 500-line program are atrocious! Those C++ standard library classes are quite costly. I estimate around ~80x slower builds compared to an equivalent C-style program.